### PR TITLE
[ASF] Move plugins mount to subdirectory

### DIFF
--- a/ASF/ArchiSteamFarm.xml
+++ b/ASF/ArchiSteamFarm.xml
@@ -67,7 +67,7 @@ Today, ASF is one of the most versatile Steam power tools, allowing you to make 
     </Volume>
     <Volume>
       <HostDir>/mnt/user/appdata/ASF/plugins</HostDir>
-      <ContainerDir>/app/plugins</ContainerDir>
+      <ContainerDir>/app/plugins/customPlugins</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
     <Volume>
@@ -80,6 +80,6 @@ Today, ASF is one of the most versatile Steam power tools, allowing you to make 
   <Labels/>
   <Config Name="WebUI" Target="1242" Default="1242" Mode="tcp" Description="By default IPC uses 1242" Type="Port" Display="always" Required="true" Mask="false">1242</Config>
   <Config Name="Appdata" Target="/app/config" Default="" Mode="rw" Description="Place the ASF.json and other files here" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/ASF/config</Config>
-  <Config Name="Plugins" Target="/app/plugins" Default="/mnt/user/appdata/ASF/plugins" Mode="rw" Description="Place your plugin files here, it is safe to remove" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/ASF/plugins</Config>
+  <Config Name="Plugins" Target="/app/plugins/customPlugins" Default="/mnt/user/appdata/ASF/plugins" Mode="rw" Description="Place your plugin files here, it is safe to remove" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/ASF/plugins</Config>
   <Config Name="Logs" Target="/app/logs" Default="/mnt/user/appdata/ASF/logs" Mode="rw" Description="Logs will be stored here, it is safe to remove" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/ASF/logs</Config>
 </Container>


### PR DESCRIPTION
Archi was repeatedly seeing an issue with Docker users in the support Discord where they were mounting over the plugins directory, which would delete any default first-party ASF plugins. Archi recommends just mounting to a subdirectory, since the plugin loader recurses subdirectories.

I realized when re-setting up Unraid, that this template had the flawed "overwrite" approach.

The [ASF wiki](https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Docker) also recently updated the docs to recommend this configuration (see "/app/plugins/MyCustomPluginDirectory"), so I don't blame you for having it in the first place.